### PR TITLE
Independent OpenLayers + GoogleMaps reprojection fixes + Resizable Maps

### DIFF
--- a/demo/maps_heatmap_layer/openlayers.html
+++ b/demo/maps_heatmap_layer/openlayers.html
@@ -115,7 +115,7 @@ function init(){
     layer = new OpenLayers.Layer.OSM();
 
    // create our heatmap layer
-   heatmap = new OpenLayers.Layer.Heatmap( "Heatmap Layer", map, layer, {visible: true, radius:10}, {isBaseLayer: false, opacity: 0.3, projection: new OpenLayers.Projection("EPSG:4326")});
+   heatmap = new OpenLayers.Layer.Heatmap( "Heatmap Layer", map, {visible: true, radius:10}, {isBaseLayer: false, opacity: 0.3, projection: new OpenLayers.Projection("EPSG:4326")});
    map.addLayers([layer, heatmap]);
   
    map.zoomToMaxExtent();

--- a/src/heatmap-gmaps.js
+++ b/src/heatmap-gmaps.js
@@ -99,6 +99,7 @@ HeatmapOverlay.prototype.pixelTransform = function(p){
 };
 
 HeatmapOverlay.prototype.setDataSet = function(data){
+    this.heatmap.clear();
     var mapdata = {
         max: data.max,
         data: []
@@ -115,9 +116,7 @@ HeatmapOverlay.prototype.setDataSet = function(data){
         var point = this.pixelTransform(projection.fromLatLngToDivPixel(latlng));
         mapdata.data.push({x: point.x, y: point.y, count: d[dlen].count});
     }
-    this.heatmap.clear();
     this.heatmap.store.setDataSet(mapdata);
-
 };
 
 HeatmapOverlay.prototype.addDataPoint = function(lat, lng, count){

--- a/src/heatmap-gmaps.js
+++ b/src/heatmap-gmaps.js
@@ -15,17 +15,17 @@ function HeatmapOverlay(map, cfg){
     me.bounds = null;
     me.setMap(map);
   
-  google.maps.event.addListener(map, 'idle', function() { me.draw();});
+    google.maps.event.addListener(map, 'idle', function() { me.draw();});
+    google.maps.event.addListener(map, 'resize', function() { me.resize();});
 }
 
 HeatmapOverlay.prototype = new google.maps.OverlayView();
 
 HeatmapOverlay.prototype.onAdd = function(){
-    
     var panes = this.getPanes(),
         w = this.getMap().getDiv().clientWidth,
         h = this.getMap().getDiv().clientHeight,
-    el = document.createElement("div");
+    	el = document.createElement("div");
     
     el.style.position = "absolute";
     el.style.top = 0;
@@ -43,6 +43,15 @@ HeatmapOverlay.prototype.onAdd = function(){
 HeatmapOverlay.prototype.onRemove = function(){
     // Empty for now.
     // TODO: Destroy this.conf.element?
+};
+
+HeatmapOverlay.prototype.resize = function(){
+	var el = this.heatmap.get('element'),
+		w = this.getMap().getDiv().clientWidth,
+		h = this.getMap().getDiv().clientHeight;
+	el.style.width = w + "px";
+	el.style.height = h + "px";
+	this.heatmap.resize();
 };
 
 HeatmapOverlay.prototype.draw = function(){
@@ -77,7 +86,6 @@ HeatmapOverlay.prototype.draw = function(){
 };
 
 HeatmapOverlay.prototype.pixelTransform = function(p){
-  
   var left = this.canvasCenter.x - this.canvasWidth / 2;
   var top = this.canvasCenter.y - this.canvasHeight / 2;
   p.x -= left;
@@ -91,7 +99,6 @@ HeatmapOverlay.prototype.pixelTransform = function(p){
 };
 
 HeatmapOverlay.prototype.setDataSet = function(data){
-
     var mapdata = {
         max: data.max,
         data: []
@@ -114,7 +121,6 @@ HeatmapOverlay.prototype.setDataSet = function(data){
 };
 
 HeatmapOverlay.prototype.addDataPoint = function(lat, lng, count){
-
     var projection = this.getProjection(),
         latlng = new google.maps.LatLng(lat, lng),
         point = this.pixelTransform(projection.fromLatLngToDivPixel(latlng));

--- a/src/heatmap-gmaps.js
+++ b/src/heatmap-gmaps.js
@@ -1,10 +1,10 @@
-/* 
+/*
  * heatmap.js GMaps overlay
  *
  * Copyright (c) 2011, Patrick Wied (http://www.patrick-wied.at)
  * Dual-licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
  * and the Beerware (http://en.wikipedia.org/wiki/Beerware) license.
- */ 
+ */
  
 function HeatmapOverlay(map, cfg){
     var me = this;
@@ -15,17 +15,17 @@ function HeatmapOverlay(map, cfg){
     me.bounds = null;
     me.setMap(map);
   
-  google.maps.event.addListener(map, 'idle', function() { me.draw() });
+  google.maps.event.addListener(map, 'idle', function() { me.draw();});
 }
 
 HeatmapOverlay.prototype = new google.maps.OverlayView();
 
 HeatmapOverlay.prototype.onAdd = function(){
-	
+    
     var panes = this.getPanes(),
         w = this.getMap().getDiv().clientWidth,
-        h = this.getMap().getDiv().clientHeight,	
-	el = document.createElement("div");
+        h = this.getMap().getDiv().clientHeight,
+    el = document.createElement("div");
     
     el.style.position = "absolute";
     el.style.top = 0;
@@ -33,97 +33,62 @@ HeatmapOverlay.prototype.onAdd = function(){
     el.style.width = w + "px";
     el.style.height = h + "px";
     el.style.border = 0;
-	
+    
     this.conf.element = el;
     panes.overlayLayer.appendChild(el);
 
     this.heatmap = h337.create(this.conf);
-}
+};
 
 HeatmapOverlay.prototype.onRemove = function(){
     // Empty for now.
-}
+    // TODO: Destroy this.conf.element?
+};
 
 HeatmapOverlay.prototype.draw = function(){
-     
-    var overlayProjection = this.getProjection(),
-        currentBounds = this.map.getBounds();
+  this.projection = this.getProjection();
+  this.canvasCenter = this.projection.fromLatLngToDivPixel(this.getMap().getCenter());
+  this.worldWidth = this.projection.getWorldWidth();
+  this.canvasWidth = Math.min(this.worldWidth, this.conf.element.offsetWidth);
+  this.canvasHeight = Math.min(this.worldWidth, this.conf.element.offsetHeight);
+  this.conf.element.style.left = this.canvasCenter.x - this.canvasWidth / 2 + 'px';
+  this.conf.element.style.top = this.canvasCenter.y - this.canvasHeight / 2 + 'px';
     
-    if (currentBounds.equals(this.bounds)) {
-      return;
-    }
-    this.bounds = currentBounds;
-    
-    var ne = overlayProjection.fromLatLngToDivPixel(currentBounds.getNorthEast()),
-        sw = overlayProjection.fromLatLngToDivPixel(currentBounds.getSouthWest()),
-        topY = ne.y,
-        leftX = sw.x,
-        h = sw.y - ne.y,
-        w = ne.x - sw.x;
-
-    this.conf.element.style.left = leftX + 'px';
-    this.conf.element.style.top = topY + 'px';
-    this.conf.element.style.width = w + 'px';
-    this.conf.element.style.height = h + 'px';
-    this.heatmap.store.get("heatmap").resize();
-            
+  this.heatmap.clear();
     if(this.latlngs.length > 0){
-    	this.heatmap.clear();
-    	
+        
         var len = this.latlngs.length,
-            projection = this.getProjection();
-            d = {
-	        max: this.heatmap.store.max,
-	        data: []
-	    };
+        projection = this.getProjection();
+
+        var d = {
+            max: this.heatmap.store.max,
+            data: []
+        };
 
         while(len--){
             var latlng = this.latlngs[len].latlng;
-	    if(!currentBounds.contains(latlng)) { continue; }
-	    	
-	    // DivPixel is pixel in overlay pixel coordinates... we need
-	    // to transform to screen coordinates so it'll match the canvas
-	    // which is continually repositioned to follow the screen.
-	    var divPixel = projection.fromLatLngToDivPixel(latlng),
-	        screenPixel = new google.maps.Point(divPixel.x - leftX, divPixel.y - topY);
-
-	    var roundedPoint = this.pixelTransform(screenPixel);
-		
-             d.data.push({ 
-	        x: roundedPoint.x,
-	        y: roundedPoint.y,
-	        count: this.latlngs[len].c
-	    });
+            var point = this.pixelTransform(projection.fromLatLngToDivPixel(latlng));
+            d.data.push({x: point.x, y: point.y, count: this.latlngs[len].c});
+            
         }
         this.heatmap.store.setDataSet(d);
     }
-}
+
+};
 
 HeatmapOverlay.prototype.pixelTransform = function(p){
-    var w = this.heatmap.get("width"),
-        h = this.heatmap.get("height");
-
-    while(p.x < 0){
-    	p.x+=w;
-    }
-	
-    while(p.x > w){
-	p.x-=w;
-    }
-		
-    while(p.y < 0){
-	p.y+=h;
-    }
-
-    while(p.y > h){
-	p.y-=h;
-    }
-
-    p.x = (p.x >> 0);
-    p.y = (p.y >> 0);
-	
+  
+  var left = this.canvasCenter.x - this.canvasWidth / 2;
+  var top = this.canvasCenter.y - this.canvasHeight / 2;
+  p.x -= left;
+  p.y -= top;
+    
+    // fast rounding - thanks to Seb Lee-Delisle for this neat hack
+    p.x = ~~ (p.x+0.5);
+    p.y = ~~ (p.y+0.5);
+    
     return p;
-}
+};
 
 HeatmapOverlay.prototype.setDataSet = function(data){
 
@@ -137,16 +102,16 @@ HeatmapOverlay.prototype.setDataSet = function(data){
 
     this.latlngs = [];
    
-    while(dlen--){	
-    	var latlng = new google.maps.LatLng(d[dlen].lat, d[dlen].lng);
-    	this.latlngs.push({latlng: latlng, c: d[dlen].count});
-    	var point = this.pixelTransform(projection.fromLatLngToDivPixel(latlng));
-    	mapdata.data.push({x: point.x, y: point.y, count: d[dlen].count});
+    while(dlen--){
+        var latlng = new google.maps.LatLng(d[dlen].lat, d[dlen].lng);
+        this.latlngs.push({latlng: latlng, c: d[dlen].count});
+        var point = this.pixelTransform(projection.fromLatLngToDivPixel(latlng));
+        mapdata.data.push({x: point.x, y: point.y, count: d[dlen].count});
     }
     this.heatmap.clear();
     this.heatmap.store.setDataSet(mapdata);
 
-}
+};
 
 HeatmapOverlay.prototype.addDataPoint = function(lat, lng, count){
 
@@ -156,8 +121,13 @@ HeatmapOverlay.prototype.addDataPoint = function(lat, lng, count){
     
     this.heatmap.store.addDataPoint(point.x, point.y, count);
     this.latlngs.push({ latlng: latlng, c: count });
-}
+};
+
+HeatmapOverlay.prototype.clear = function(){
+    this.heatmap.clear();
+};
 
 HeatmapOverlay.prototype.toggle = function(){
     this.heatmap.toggleDisplay();
-}
+};
+

--- a/src/heatmap-openlayers.js
+++ b/src/heatmap-openlayers.js
@@ -41,6 +41,12 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
 	    map.events.register("zoomend", this, handler);
 	    map.events.register("moveend", this, handler);
         },
+	onMapResize: function(){
+		var el = this.heatmap.get('element');
+		el.style.width = this.map.size.w+'px';
+		el.style.height = this.map.size.h+'px';
+		this.heatmap.resize();
+	},
 	updateLayer: function(){
                 var pixelOffset = this.getPixelOffset(),
                     el = this.heatmap.get('element');

--- a/src/heatmap-openlayers.js
+++ b/src/heatmap-openlayers.js
@@ -15,10 +15,9 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
 	// the heatmap isn't a basic layer by default - you usually want to display the heatmap over another map ;)
 	isBaseLayer: false,
 	heatmap: null,
-	mapLayer: null,
 	// we store the lon lat data, because we have to redraw with new positions on zoomend|moveend
 	tmpData: {},
-        initialize: function(name, map, mLayer, hmoptions, options){
+        initialize: function(name, map, hmoptions, options){
             var heatdiv = document.createElement("div"),
                 handler;
 
@@ -29,7 +28,6 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
 	    this.div.appendChild(heatdiv);
 	    // add to our heatmap.js config
 	    hmoptions.element = heatdiv;
-	    this.mapLayer = mLayer;
 	    this.map = map;
             // create the heatmap with passed heatmap-options
 	    this.heatmap = h337.create(hmoptions);
@@ -54,12 +52,12 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
                 this.setDataSet(this.tmpData);
 	},
         getPixelOffset: function () {
-            var o = this.mapLayer.map.layerContainerOrigin,
+            var o = this.map.layerContainerOrigin,
                 o_lonlat = new OpenLayers.LonLat(o.lon, o.lat),
-                o_pixel = this.mapLayer.getViewPortPxFromLonLat(o_lonlat),
-                c = this.mapLayer.map.center,
+                o_pixel = this.map.getViewPortPxFromLonLat(o_lonlat),
+                c = this.map.center,
                 c_lonlat = new OpenLayers.LonLat(c.lon, c.lat),
-                c_pixel = this.mapLayer.getViewPortPxFromLonLat(c_lonlat);
+                c_pixel = this.map.getViewPortPxFromLonLat(c_lonlat);
 
             return { 
                 x: o_pixel.x - c_pixel.x,
@@ -101,8 +99,8 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
 	},
 	// same procedure as setDataSet
 	addDataPoint: function(lonlat){
-	    var pixel = this.roundPixels(this.mapLayer.getViewPortPxFromLonLat(lonlat)),
-                entry = {lonlat: lonlat};
+	    var pixel = this.roundPixels(this.map.getViewPortPxFromLonLat(lonlat)),
+                entry = {lonlat: lonlat},
                 args;
 
             if(arguments.length == 2){

--- a/src/heatmap-openlayers.js
+++ b/src/heatmap-openlayers.js
@@ -32,10 +32,8 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
             // create the heatmap with passed heatmap-options
 	    this.heatmap = h337.create(hmoptions);
 
-            handler = function(){ 
-                if(this.tmpData.max){
-                    this.updateLayer(); 
-                }
+            handler = function(){
+                this.updateLayer();
             };
 	    // on zoomend and moveend we have to move the canvas element and redraw the datapoints with new positions
 	    map.events.register("zoomend", this, handler);
@@ -74,7 +72,7 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
 	setDataSet: function(obj){
 	    var set = {},
 		dataset = obj.data,
-		dlen = dataset.length,
+		dlen = dataset!=undefined?dataset.length:0,
                 entry, lonlat, pixel;
 
 		set.max = obj.max;

--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -264,10 +264,15 @@
         colorize: function(x, y){
                 // get the private variables
                 var me = this,
-                    width = me.get("width"),
                     radiusOut = me.get("radiusOut"),
-                    height = me.get("height"),
-                    actx = me.get("actx"),
+                    width = me.get("width"),
+                    height = me.get("height");
+                // skip out of range
+		if (x<(-radiusOut) || x>(width+radiusOut) ||
+		    y<(-radiusOut) || y>(height+radiusOut))
+			return;
+                // get the private variables
+                var actx = me.get("actx"),
                     ctx = me.get("ctx");
                 
                 var x2 = radiusOut*2;
@@ -312,11 +317,16 @@
                 ctx.putImageData(image,x,y);    
         },
         drawAlpha: function(x, y, count){
-                // storing the variables because they will be often used
                 var me = this,
                     r1 = me.get("radiusIn"),
                     r2 = me.get("radiusOut"),
-                    ctx = me.get("actx"),
+                    width = me.get("width"),
+                    height = me.get("height");
+                // skip out of range
+		if (x<(-r2) || x>(width+r2) || y<(-r2) || y>(height+r2))
+			return;
+                // storing the variables because they will be often used
+                var ctx = me.get("actx"),
                     max = me.get("max"),
                     // create a radial gradient with the defined parameters. we want to draw an alphamap
                     rgr = ctx.createRadialGradient(x,y,r1,x,y,r2),


### PR DESCRIPTION
I have a fully functional GoogleMaps with no errors.

I also changed OpenLayers Layer API to use only the map object, now it didn't need to be passed any other layer object.

The fixes of GoogleMaps implementation are inspired by @jackquack patches but fixing also some bugs of his fork.

Added support to be able to resize the map dynamically.