### PR TITLE
Fixed a bug in the openlayers implementation of addDataPoint

### DIFF
--- a/src/heatmap-openlayers.js
+++ b/src/heatmap-openlayers.js
@@ -102,7 +102,7 @@ OpenLayers.Layer.Heatmap = OpenLayers.Class(OpenLayers.Layer, {
 	// same procedure as setDataSet
 	addDataPoint: function(lonlat){
 	    var pixel = this.roundPixels(this.mapLayer.getViewPortPxFromLonLat(lonlat)),
-                entry = {lonlat: lonlat};
+                entry = {lonlat: lonlat},
                 args;
 
             if(arguments.length == 2){


### PR DESCRIPTION
Looks like there was a semicolon in the variable definitions for addDataPoint.
