### PR TITLE
OL 2.12 requires more css.

### DIFF
--- a/website/example-heatmap-openlayers.html
+++ b/website/example-heatmap-openlayers.html
@@ -16,6 +16,9 @@
         padding-top: 60px;
         padding-bottom: 40px;
       }
+      #heatmapArea img {
+        max-width: none;
+      }
     </style>
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
@@ -130,7 +133,7 @@ window.onload = function(){
 
     while(datalen--){
         nudata.push({
-            lonlat: new OpenLayers.LonLat(data[datalen].lon, data[datalen].lat),
+            lonlat: new OpenLayers.LonLat(data[datalen].lng, data[datalen].lat),
             count: data[datalen].count
         });
     }


### PR DESCRIPTION
This fixes the incorrect display of the OSM layer when using `css/bootstrap.css`

... and put of coherence in the name of var for longitude.
