### PR TITLE
unnecessary Leaflet override of tileDrawn

### DIFF
--- a/src/heatmap-leaflet.js
+++ b/src/heatmap-leaflet.js
@@ -189,10 +189,6 @@
         heatmap.store.setDataSet({max: this._getMaxValue(), data: pointsInTile});
 
         return this;
-    },
-
-    tileDrawn: function (tile) {
-        this._tileOnLoad.call(tile);
     }
 });
 


### PR DESCRIPTION
tileDrawn is a duplicate of the one built into core.
