### PR TITLE
add a default value for radius

### DIFF
--- a/src/heatmap-leaflet.js
+++ b/src/heatmap-leaflet.js
@@ -170,7 +170,7 @@
             options = this.options,
             tile = ctx.canvas,
             tileSize = options.tileSize,
-            radiusValue = this.options.radius.value;
+            radiusValue = this.options.radius.value || 20;
 
         var localXY, value, pointsInTile = [];
 


### PR DESCRIPTION
I added a default value for the radius.  Without this, if the radius is missing, you get Error: Invalid LatLng object: (NaN, NaN) when trying to calculate the bounds for an undefined point (lines 199-203).

The leaflet sample code (http://www.patrick-wied.at/static/heatmapjs/example-heatmap-leaflet.html) also needs to be updated, but I didn't see that in the github source:

radius should have value and absolute fields:

```
<                     radius: 20,

---
>                     radius: { value: 20, absolute: false },
```

method to set data has changed:

```
< heatmapLayer.addData(testData.data);

---
> heatmapLayer.setData(testData.data);
```
