### PR TITLE
Don't create new heatmap if one already exists

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -29,8 +29,10 @@ var HeatmapOverlay = L.Class.extend({
     this._resetOrigin();
 
     map.getPanes().overlayPane.appendChild(this._el);
-
-    this._heatmap = h337.create(this.cfg);
+    
+    if(this._heatmap === undefined) {
+      this._heatmap = h337.create(this.cfg);
+    }
     // on zoom, reset origin
     map.on('viewreset', this._resetOrigin, this);
     // redraw whenever dragend


### PR DESCRIPTION
This was causing duplicate canvases if layers were removed and added.

Scenario I was having: Hide layer at some zoom level and re-add it when zooming out again. Each time I zoomed in and out, I had a new canvas in the DOM and multiple heatmaps on top of each other.

This may be fixed in a better way, but this fixed it for me.
