### PR TITLE
Added Leaflet 0.8 compatibility

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -8,7 +8,7 @@
 
 // Leaflet < 0.8 compatibility
 if (typeof L.Layer === 'undefined') {
-    L.Layer = L.Class;
+  L.Layer = L.Class;
 }
 
 var HeatmapOverlay = L.Layer.extend({


### PR DESCRIPTION
In Leaflet 0.8, custom layers should extend L.Layer instead of L.Class.
Compatibility with current Leaflet version is retained.
