### PR TITLE
addTo() method for Leaflet plugin

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -179,7 +179,11 @@ var HeatmapOverlay = L.Layer.extend({
   _resetOrigin: function () {
     this._origin = this._map.layerPointToLatLng(new L.Point(0, 0));
     this._draw();
-  } 
+  },
+  addTo: function (map) {
+    map.addLayer(this);
+    return this;
+  }
 });
 
 HeatmapOverlay.CSS_TRANSFORM = (function() {


### PR DESCRIPTION
All the Leaflet layers have addTo() method. Therefore, for possibility of working with heatmap.js layer the same way as with other layers, it is necessary to implement the addTo() method.
