### PR TITLE
Ensure the heatmap (with leaflet plugin) is cleared when calling setData with an empty dataset

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -76,6 +76,9 @@ var HeatmapOverlay = L.Layer.extend({
     scale = Math.pow(2, zoom);
 
     if (this._data.length == 0) {
+      if (this._heatmap) {
+        this._heatmap.setData({data:[]});
+      }
       return;
     }
 


### PR DESCRIPTION
With the current leaflet plugin, calling setData with an empty dataset doesn't clear the heatmap and keeps displaying the last image with data. This is a quick fix for this issue.
