### PR TITLE
Update leaflet-heatmap.js

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -75,11 +75,15 @@ var HeatmapOverlay = L.Layer.extend({
     zoom = this._map.getZoom();
     scale = Math.pow(2, zoom);
 
+    var generatedData = { max: this._max, min: this._min, data: [] };
+    
     if (this._data.length == 0) {
-      return;
+		  if (this._heatmap) {
+			  this._heatmap.setData(generatedData);
+		  }
+		  return;
     }
-
-    var generatedData = { max: this._max, min: this._min };
+    
     var latLngPoints = [];
     var radiusMultiplier = this.cfg.scaleRadius ? scale : 1;
     var localMax = 0;


### PR DESCRIPTION
Allows user to reset/clear the heatmap by using `.setData()` with an object with an empty array as `data` property.
In current situation, setting empty data returns without clearing the heatmap picture.