### PR TITLE
Fix #148; allow multiple heatmap layers in leaflet

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -66,6 +66,8 @@ var HeatmapOverlay = L.Layer.extend({
       -Math.round(point.x) + 'px,' +
       -Math.round(point.y) + 'px)';
 
+    this._el.style.position = 'absolute';
+
     this._update();
   },
   _update: function() {


### PR DESCRIPTION
Issue fixed by setting `position` of the container to `absolute`. Default was `relative` and caused the layer to be positioned out-of-view.