### PR TITLE
publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .DS_Store
 support
+.idea
+dist

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
       npmRelease: {
         command: [
           'cd dist',
-          'npm -v'
+          'npm publish'
         ].join('&&')
       }
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,24 @@ module.exports = function(grunt) {
         files: packagejson.buildFiles,
         tasks: ['concat', 'jshint', 'uglify']
       }
+    },
+    copy: {
+      npmPreRelease: {
+        files: [
+          { flatten: true, expand: true, src: 'build/*', dest: 'dist/' },
+          { src: 'package.json', dest: 'dist/' },
+          { src: 'LICENSE', dest: 'dist/' },
+          { src: 'README.md', dest: 'dist/' }
+        ]
+      }
+    },
+    shell: {
+      npmRelease: {
+        command: [
+          'cd dist',
+          'npm -v'
+        ].join('&&')
+      }
     }
   });
 
@@ -66,7 +84,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-shell');
+
 
   // Default task.
   grunt.registerTask('default', ['concat', 'jshint', 'uglify', 'watch']);
+  grunt.registerTask('publishToNpm', ['concat', 'jshint', 'uglify', 'copy:npmPreRelease', 'shell:npmRelease']);
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "grunt-contrib-uglify": ">= 0.2.0",
     "grunt-contrib-concat": ">= 0.1.3",
     "grunt-contrib-watch": "0.2.0rc7",
-    "grunt-contrib-jshint": ">= 0.3.0"
+    "grunt-contrib-jshint": ">= 0.3.0",
+    "grunt-contrib-copy": ">= 0.7.0",
+    "grunt-shell": "^0.7.0"
   },
   "buildFiles": [
     "src/config.js", 


### PR DESCRIPTION
NPM is becoming the standard way to distribute JavaScript-based code libraries, both browser-based and server-based.  It would be great if heatmap.js was available on npm as well.  And it's pretty simple to do this.  I made it even easier in this pull request.  Simply run `grunt publishToNpm`.