### PR TITLE
allow the valueField option to be used with the default value ('value')

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -84,7 +84,7 @@ var HeatmapOverlay = L.Layer.extend({
     var radiusMultiplier = this.cfg.scaleRadius ? scale : 1;
     var localMax = 0;
     var localMin = 0;
-    var valueField = this.cfg.valueField;
+    var valueField = this.cfg.valueField || 'value';
     var len = this._data.length;
   
     while (len--) {


### PR DESCRIPTION
The default value for this option is not working because of the missing or operator (which is used in the `setData` and `addData` methods).