### PR TITLE
Updated package.json with more metadata

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,27 +58,6 @@ module.exports = function(grunt) {
         files: packagejson.buildFiles,
         tasks: ['concat', 'jshint', 'uglify']
       }
-    },
-    copy: {
-      npmPreRelease: {
-        files: [
-          { flatten: true, expand: true, src: 'build/*', dest: 'dist/' },
-          { expand:true, src: 'build/*/**', dest: 'dist/' },
-          { expand:true, src: 'examples/*/**', dest: 'dist/' },
-          { expand: true, src: 'docs/*/**', dest: 'dist/' },
-          { src: 'package.json', dest: 'dist/' },
-          { src: 'LICENSE', dest: 'dist/' },
-          { src: 'README.md', dest: 'dist/' }
-        ]
-      }
-    },
-    shell: {
-      npmRelease: {
-        command: [
-          'cd dist',
-          'npm publish'
-        ].join('&&')
-      }
     }
   });
 
@@ -87,11 +66,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-shell');
 
 
   // Default task.
   grunt.registerTask('default', ['concat', 'jshint', 'uglify', 'watch']);
-  grunt.registerTask('publishToNpm', ['concat', 'jshint', 'uglify', 'copy:npmPreRelease', 'shell:npmRelease']);
 };

--- a/package.json
+++ b/package.json
@@ -3,15 +3,20 @@
   "version": "2.0.1",
   "description": "Dynamic JavaScript Heatmaps for the Web",
   "homepage": "http://www.patrick-wied.at/static/heatmapjs/",
+  "author": {
+    "name": "Patrick Wied",
+    "email": "contact@patrick-wied.at",
+    "url": "http://www.patrick-wied.at/"
+  },
+  "main": "build/heatmap.js",
+  "repository": "pa7/heatmap.js",
   "devDependencies": {
     "grunt": ">= 0.4.1",
     "coffee-script": ">= 1.6.3",
     "grunt-contrib-uglify": ">= 0.2.0",
     "grunt-contrib-concat": ">= 0.1.3",
     "grunt-contrib-watch": "0.2.0rc7",
-    "grunt-contrib-jshint": ">= 0.3.0",
-    "grunt-contrib-copy": ">= 0.7.0",
-    "grunt-shell": "^0.7.0"
+    "grunt-contrib-jshint": ">= 0.3.0"
   },
   "keywords": [
     "heatmap",
@@ -22,12 +27,21 @@
     "leaflet heatmap",
     "leaflet"
   ],
+  "files": [
+    "build",
+    "plugins",
+    "examples",
+    "docs",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "buildFiles": [
-    "src/config.js", 
-    "src/data.js", 
-    "src/renderer/canvas2d.js", 
-    "src/renderer.js", 
-    "src/util.js", 
+    "src/config.js",
+    "src/data.js",
+    "src/renderer/canvas2d.js",
+    "src/renderer.js",
+    "src/util.js",
     "src/core.js"
   ]
 }


### PR DESCRIPTION
Most importantly, I added a `main` field, which lets node (Browserify) know which file to import when the package is required. I also added a link to the repo and details on the author.

I removed the Grunt task for publishing to npm in favor of the `files` field in package.json, which determines what files get included when the package is published to npm.

Lastly, I included the plugins folder, which previously didn't make it into the npm bundle.