### PR TITLE
Leaflet plugin: don't call _resetOrigin in onAdd

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -47,13 +47,13 @@
       this._el.style.height = size.y + 'px';
       this._el.style.position = 'absolute';
 
-      this._resetOrigin();
+      this._origin = this._map.layerPointToLatLng(new L.Point(0, 0));
 
       map.getPanes().overlayPane.appendChild(this._el);
 
       if (!this._heatmap) {
         this._heatmap = h337.create(this.cfg);
-      } 
+      }
 
       // on zoom, reset origin
       map.on('viewreset', this._resetOrigin, this);
@@ -72,9 +72,9 @@
     },
     _draw: function() {
       if (!this._map) { return; }
-      
+
       var mapPane = this._map.getPanes().mapPane;
-      var point = mapPane._leaflet_pos;      
+      var point = mapPane._leaflet_pos;
 
       // reposition the layer
       this._el.style[HeatmapOverlay.CSS_TRANSFORM] = 'translate(' +
@@ -105,7 +105,7 @@
       var localMin = 0;
       var valueField = this.cfg.valueField;
       var len = this._data.length;
-    
+
       while (len--) {
         var entry = this._data[len];
         var value = entry[valueField];
@@ -149,12 +149,12 @@
       var latField = this.cfg.latField || 'lat';
       var lngField = this.cfg.lngField || 'lng';
       var valueField = this.cfg.valueField || 'value';
-    
+
       // transform data to latlngs
       var data = data.data;
       var len = data.length;
       var d = [];
-    
+
       while (len--) {
         var entry = data[len];
         var latlng = new L.LatLng(entry[latField], entry[lngField]);
@@ -166,7 +166,7 @@
         d.push(dataObj);
       }
       this._data = d;
-    
+
       this._draw();
     },
     // experimential... not ready.
@@ -183,7 +183,7 @@
         var entry = pointOrArray;
         var latlng = new L.LatLng(entry[latField], entry[lngField]);
         var dataObj = { latlng: latlng };
-        
+
         dataObj[valueField] = entry[valueField];
         this._max = Math.max(this._max, dataObj[valueField]);
         this._min = Math.min(this._min, dataObj[valueField]);
@@ -198,7 +198,7 @@
     _resetOrigin: function () {
       this._origin = this._map.layerPointToLatLng(new L.Point(0, 0));
       this._draw();
-    } 
+    }
   });
 
   HeatmapOverlay.CSS_TRANSFORM = (function() {


### PR DESCRIPTION
Avoid drawing the heatmap in onAdd before we check is the `_heatmap` property is set. The fact that `_resetOrigin` was called was triggering errors for me when allowing the user to dynamically add/remove the heatmap layer from the map.

This PR simply takes the line that actually resets the origin in resetOrigin and uses that instead of calling the actual method (which in turns calls _draw, which caused the issues, since _heatmap was undefined when _draw was called).

This should fix #130.

PS. my editor cleaned up some trailing whitespace as well, made for a somewhat more messy commit, but figured I could leave those changes in there.