### PR TITLE
HEATMAP-fix: fromLatLngToDivPixel of undefined for google maps

### DIFF
--- a/plugins/gmaps-heatmap.js
+++ b/plugins/gmaps-heatmap.js
@@ -19,7 +19,7 @@
 
 })("HeatmapOverlay", this, function() {
 
-  var HeatmapOverlay = function(map, cfg){ 
+  var HeatmapOverlay = function(map, cfg){
     this.setMap(map);
     this.initialize(cfg || {});
   };
@@ -49,7 +49,7 @@
 
   HeatmapOverlay.prototype.initialize = function(cfg) {
     this.cfg = cfg;
-    
+
     var map = this.map = this.getMap();
     var container = this.container = document.createElement('div');
     var mapDiv = map.getDiv();
@@ -74,14 +74,14 @@
       'bounds_changed',
       this.draw
     );
-   
+
     if (!this.heatmap) {
       this.heatmap = h337.create(this.cfg);
     }
     this.draw();
   };
 
-  HeatmapOverlay.prototype.onRemove = function() { 
+  HeatmapOverlay.prototype.onRemove = function() {
     if (!this.map) { return; }
 
     this.map = null;
@@ -135,7 +135,7 @@
   };
 
   HeatmapOverlay.prototype.update = function() {
-    var projection = this.map.getProjection(),
+    var projection = this.getProjection(),
       zoom, scale, bounds, topLeft;
     var generatedData = { max: this.max, min: this.min, data: [] };
 
@@ -162,7 +162,7 @@
 
 
     var latLngPoints = [];
-    // iterate through data 
+    // iterate through data
     var len = this.data.length;
     var layerProjection = this.getProjection();
     var layerOffset = layerProjection.fromLatLngToDivPixel(topLeft);
@@ -227,7 +227,7 @@
     return point;
   };
 
-  HeatmapOverlay.prototype.setData = function(data) { 
+  HeatmapOverlay.prototype.setData = function(data) {
     this.max = data.max;
     this.min = data.min;
 
@@ -267,7 +267,7 @@
         var entry = pointOrArray;
         var latlng = new google.maps.LatLng(entry[latField], entry[lngField]);
         var dataObj = { latlng: latlng };
-        
+
         dataObj[valueField] = entry[valueField];
         if (entry.radius) {
           dataObj.radius = entry.radius;


### PR DESCRIPTION
* Fixes the `TypeError: Cannot read property 'fromLatLngToDivPixel' of undefined when showing a google maps heatmap:
![screen shot 2015-08-14 at 10 18 47 am](https://cloud.githubusercontent.com/assets/1031738/9277184/17d8da7a-426e-11e5-9e46-ee8bde611adf.png)
* Also cleaned up a few spurious spaces.