### PR TITLE
Added support for drawing uncliped heat maps

### DIFF
--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -59,6 +59,8 @@
       map.on('viewreset', this._resetOrigin, this);
       // redraw whenever dragend
       map.on('dragend', this._draw, this);
+      // redraw when drag momentum is 0
+      map.on('moveend', this._draw, this);
 
       this._draw();
     },
@@ -105,6 +107,7 @@
       var localMin = 0;
       var valueField = this.cfg.valueField;
       var len = this._data.length;
+      var clip = this.cfg.clip;
     
       while (len--) {
         var entry = this._data[len];
@@ -113,7 +116,7 @@
 
 
         // we don't wanna render points that are not even on the map ;-)
-        if (!bounds.contains(latlng)) {
+        if (!clip && !bounds.contains(latlng)) {
           continue;
         }
         // local max is the maximum within current bounds
@@ -223,3 +226,4 @@
 
   return HeatmapOverlay;
 });
+

--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -108,8 +108,6 @@
       var valueField = this.cfg.valueField;
       var len = this._data.length;
       var clip = this.cfg.clip !== undefined ? this.cfg.clip : true;
-      console.log("CLIP: ", clip);
-      console.log("CFG.CLIP", this.cfg.clip);
     
       while (len--) {
         var entry = this._data[len];

--- a/plugins/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap.js
@@ -60,7 +60,7 @@
       // redraw whenever dragend
       map.on('dragend', this._draw, this);
       // redraw when drag momentum is 0
-      map.on('moveend', this._draw, this);
+      map.on('moveend', this._draw, this); 
 
       this._draw();
     },
@@ -107,7 +107,9 @@
       var localMin = 0;
       var valueField = this.cfg.valueField;
       var len = this._data.length;
-      var clip = this.cfg.clip;
+      var clip = this.cfg.clip !== undefined ? this.cfg.clip : true;
+      console.log("CLIP: ", clip);
+      console.log("CFG.CLIP", this.cfg.clip);
     
       while (len--) {
         var entry = this._data[len];
@@ -116,7 +118,7 @@
 
 
         // we don't wanna render points that are not even on the map ;-)
-        if (!clip && !bounds.contains(latlng)) {
+        if (clip && !bounds.contains(latlng)) {
           continue;
         }
         // local max is the maximum within current bounds
@@ -226,4 +228,3 @@
 
   return HeatmapOverlay;
 });
-


### PR DESCRIPTION
Added support for drawing an uncliped heatmap by setting the config option "clip: false"

The default is to mimic old functionality.
