### PR TITLE
Fix crash when no data is visible

### DIFF
--- a/src/renderer/canvas2d.js
+++ b/src/renderer/canvas2d.js
@@ -1,6 +1,6 @@
 
 var Canvas2dRenderer = (function Canvas2dRendererClosure() {
-  
+
   var _getColorPalette = function(config) {
     var gradientConfig = config.gradient || config.defaultGradient;
     var paletteCanvas = document.createElement('canvas');
@@ -39,8 +39,8 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
       tplCtx.fillStyle = gradient;
       tplCtx.fillRect(0, 0, 2*radius, 2*radius);
     }
-    
-    
+
+
 
     return tplCanvas;
   };
@@ -51,7 +51,7 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
     var max = data.max;
     var radi = data.radi;
     var data = data.data;
-    
+
     var xValues = Object.keys(data);
     var xValuesLen = xValues.length;
 
@@ -112,14 +112,18 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
 
   Canvas2dRenderer.prototype = {
     renderPartial: function(data) {
-      this._drawAlpha(data);
-      this._colorize();
+      if (data.data.length > 0) {
+        this._drawAlpha(data);
+        this._colorize();
+      }
     },
     renderAll: function(data) {
       // reset render boundaries
       this._clear();
-      this._drawAlpha(_prepareData(data));
-      this._colorize();
+      if (data.data.length > 0) {
+        this._drawAlpha(_prepareData(data));
+        this._colorize();
+      }
     },
     _updateGradient: function(config) {
       this._palette = _getColorPalette(config);
@@ -192,7 +196,7 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
         // update renderBoundaries
         if (rectX < this._renderBoundaries[0]) {
             this._renderBoundaries[0] = rectX;
-          } 
+          }
           if (rectY < this._renderBoundaries[1]) {
             this._renderBoundaries[1] = rectY;
           }


### PR DESCRIPTION
In the leaflet plugin, we've been running into an issue where in some slower browsers, calling shadowCtx.getImageData(1000, 1000, -1000, -1000) hangs for several seconds or even crashes the browser. These parameters are the default values of x/y/width/height, and so are used when there is data on the heatmap, but none of it is visible. This fix prevents rendering when there's nothing to render.

Definitely happy to discuss other solutions - this was the simplest one that I found, but it could certainly have implications that I didn't consider.