### PR TITLE
Canvas2dRenderer can be configurated with a determinated width and height

### DIFF
--- a/src/renderer/canvas2d.js
+++ b/src/renderer/canvas2d.js
@@ -90,8 +90,8 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
 
     canvas.className = 'heatmap-canvas';
 
-    this._width = canvas.width = shadowCanvas.width = +(computed.width.replace(/px/,''));
-    this._height = canvas.height = shadowCanvas.height = +(computed.height.replace(/px/,''));
+    this._width = canvas.width = shadowCanvas.width = config.width || +(computed.width.replace(/px/,''));
+    this._height = canvas.height = shadowCanvas.height = config.height || +(computed.height.replace(/px/,''));
 
     this.shadowCtx = shadowCanvas.getContext('2d');
     this.ctx = canvas.getContext('2d');


### PR DESCRIPTION
Canvas2dRenderer accepts the width and height, and is necesary with a data with specific X and Y position and determinated map size.

You can configure with:

```
h337.create({
	width: 1200,
	height: 600,
	container: document.getElementById('map'),
	radius: 12
});
```