### PR TITLE
Also add plugins folder to dist folder for npm publish

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,7 @@ module.exports = function(grunt) {
           { expand:true, src: 'build/*/**', dest: 'dist/' },
           { expand:true, src: 'examples/*/**', dest: 'dist/' },
           { expand: true, src: 'docs/*/**', dest: 'dist/' },
+          { expand: true, src: 'plugins/*', dest: 'dist/' },
           { src: 'package.json', dest: 'dist/' },
           { src: 'LICENSE', dest: 'dist/' },
           { src: 'README.md', dest: 'dist/' }


### PR DESCRIPTION
The plugins folder is not copied to the npm dist folder that is published, so when heatmap.js is installed via npm, there is no way to use the plugins as well.

Now you can use the plugins via `require('heatmap.js/plugins/leaflet-plugin')`.
`require('heatmap.js')` will continue to work as normal.