### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npx serve examples"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # heatmap.js
+
+[![run on repl.it](http://repl.it/badge/github/pa7/heatmap.js)](https://repl.it/github/pa7/heatmap.js)
+
 Dynamic Heatmaps for the Web. 
 
 [<img src="http://www.patrick-wied.at/static/heatmapjs/assets/img/heatmapjs-examples-docs-banner.jpg" width="100%">](http://www.patrick-wied.at/static/heatmapjs/?utm_source=gh "View the heatmap.js website with usage examples, showcases, best practises, plugins ( googlemaps heatmap, leaflet) and more.")


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-heatmap.js):

![image](https://i.imgur.com/uKXb5sM.png)
