### PR TITLE
Update canvas2d.js

### DIFF
--- a/src/renderer/canvas2d.js
+++ b/src/renderer/canvas2d.js
@@ -278,7 +278,6 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
 
       }
 
-      img.data = imgData;
       this.ctx.putImageData(img, x, y);
 
       this._renderBoundaries = [1000, 1000, 0, 0];


### PR DESCRIPTION
This is throwing an exception in Chrome 79.0.3945.130.  Cannot assign to read only property 'data' of object '[object ImageData]'
This line is unnecessary since img.Data is being mutated by imgData changes.