### PR TITLE
docs: Fix simple typo, experimential -> experimental

### DIFF
--- a/plugins/gmaps-heatmap/gmaps-heatmap.js
+++ b/plugins/gmaps-heatmap/gmaps-heatmap.js
@@ -247,7 +247,7 @@
     this.data = d;
     this.update();
   };
-  // experimential. not ready yet.
+  // experimental. not ready yet.
   HeatmapOverlay.prototype.addData = function(pointOrArray) {
     if (pointOrArray.length > 0) {
         var len = pointOrArray.length;

--- a/plugins/leaflet-heatmap/leaflet-heatmap.js
+++ b/plugins/leaflet-heatmap/leaflet-heatmap.js
@@ -180,7 +180,7 @@
     
       this._draw();
     },
-    // experimential... not ready.
+    // experimental... not ready.
     addData: function(pointOrArray) {
       if (pointOrArray.length > 0) {
         var len = pointOrArray.length;

--- a/tests/visual/plugin-modules/gmaps-heatmap.js
+++ b/tests/visual/plugin-modules/gmaps-heatmap.js
@@ -248,7 +248,7 @@
     this.data = d;
     this.update();
   };
-  // experimential. not ready yet.
+  // experimental. not ready yet.
   HeatmapOverlay.prototype.addData = function(pointOrArray) {
     if (pointOrArray.length > 0) {
         var len = pointOrArray.length;


### PR DESCRIPTION
There is a small typo in plugins/gmaps-heatmap/gmaps-heatmap.js, plugins/leaflet-heatmap/leaflet-heatmap.js, tests/visual/plugin-modules/gmaps-heatmap.js.

Should read `experimental` rather than `experimential`.

