### PR TITLE
Cast color stop offset to number

### DIFF
--- a/src/renderer/canvas2d.js
+++ b/src/renderer/canvas2d.js
@@ -11,7 +11,7 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
 
     var gradient = paletteCtx.createLinearGradient(0, 0, 256, 1);
     for (var key in gradientConfig) {
-      gradient.addColorStop(key, gradientConfig[key]);
+      gradient.addColorStop(+key, gradientConfig[key]);
     }
 
     paletteCtx.fillStyle = gradient;


### PR DESCRIPTION
Will parse the offset to number so heatmap.js can be used with local jest tests (canvas node implementation).
closes #330