### PR TITLE
The value of templateAlpha will be NaN if max is equal to min.

### DIFF
--- a/src/renderer/canvas2d.js
+++ b/src/renderer/canvas2d.js
@@ -193,7 +193,7 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
         }
         // value from minimum / value range
         // => [0, 1]
-        var templateAlpha = (value-min)/(max-min);
+        var templateAlpha = max === min ? 1 : (value - min) / (max - min);
         // this fixes #176: small values are not visible because globalAlpha < .01 cannot be read from imageData
         shadowCtx.globalAlpha = templateAlpha < .01 ? .01 : templateAlpha;
 


### PR DESCRIPTION
Actually NaN does not lead to a bug, cause I find something below about globalAlpha on MDN:
"Values outside that range, including Infinity and NaN, will not be set, and globalAlpha will retain its previous value."
And, of course. The default value is 1.
However, I do not think it is a good idea to compare a number with NaN.
Hope this commit will help.