### PR TITLE
Remove unneeded code that was causing error

### DIFF
--- a/build/heatmap.js
+++ b/build/heatmap.js
@@ -524,7 +524,6 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
 
       }
 
-      img.data = imgData;
       this.ctx.putImageData(img, x, y);
 
       this._renderBoundaries = [1000, 1000, 0, 0];


### PR DESCRIPTION
Fixes error: Cannot assign to read only property 'data' of object '[object ImageData]'

Error appears to have appeared now after updating TS library in project. The issue has been identified in original library since 2017, and PR have been created to fix this issue but author hasn't merge them.